### PR TITLE
fix on gps-entity-place attribute and places-name example

### DIFF
--- a/examples/click-places/places.js
+++ b/examples/click-places/places.js
@@ -67,7 +67,7 @@ window.onload = () => {
 
                     // add place icon
                     const icon = document.createElement('a-image');
-                    icon.setAttribute('gps-entity-place', `latitude: ${latitude}; longitude: ${longitude}`);
+                    icon.setAttribute('data-gps_entity_place', `latitude: ${latitude}; longitude: ${longitude}`);
                     icon.setAttribute('name', place.name);
                     icon.setAttribute('src', '../assets/map-marker.png');
 
@@ -79,11 +79,11 @@ window.onload = () => {
                     const clickListener = function(ev) {
                         ev.stopPropagation();
                         ev.preventDefault();
-            
+
                         const name = ev.target.getAttribute('name');
-            
+
                         const el = ev.detail.intersection && ev.detail.intersection.object.el;
-            
+
                         if (el && el === ev.target) {
                             const label = document.createElement('span');
                             const container = document.createElement('div');
@@ -91,13 +91,13 @@ window.onload = () => {
                             label.innerText = name;
                             container.appendChild(label);
                             document.body.appendChild(container);
-            
+
                             setTimeout(() => {
                                 container.parentElement.removeChild(container);
                             }, 1500);
                         }
                     };
-            
+
                     icon.addEventListener('click', clickListener);
 
                     scene.appendChild(icon);

--- a/examples/click-places/places.js
+++ b/examples/click-places/places.js
@@ -67,7 +67,7 @@ window.onload = () => {
 
                     // add place icon
                     const icon = document.createElement('a-image');
-                    icon.setAttribute('data-gps_entity_place', `latitude: ${latitude}; longitude: ${longitude}`);
+                    icon.setAttribute('data-gps-entity-place', `latitude: ${latitude}; longitude: ${longitude}`);
                     icon.setAttribute('name', place.name);
                     icon.setAttribute('src', '../assets/map-marker.png');
 

--- a/examples/click-places/places.js
+++ b/examples/click-places/places.js
@@ -8,6 +8,7 @@ const loadPlaces = function(coords) {
             location: {
                 lat: 0, // add here latitude if using static data
                 lng: 0, // add here longitude if using static data
+
             }
         },
     ];
@@ -67,7 +68,7 @@ window.onload = () => {
 
                     // add place icon
                     const icon = document.createElement('a-image');
-                    icon.setAttribute('data-gps-entity-place', `latitude: ${latitude}; longitude: ${longitude}`);
+                    icon.setAttribute('gps-entity-place', `latitude: ${latitude}; longitude: ${longitude}`);
                     icon.setAttribute('name', place.name);
                     icon.setAttribute('src', '../assets/map-marker.png');
 
@@ -99,7 +100,7 @@ window.onload = () => {
                     };
 
                     icon.addEventListener('click', clickListener);
-
+                    
                     scene.appendChild(icon);
                 });
             })

--- a/examples/places-name/places.js
+++ b/examples/places-name/places.js
@@ -16,7 +16,7 @@ const loadPlaces = function (coords) {
         return loadPlaceFromAPIs(coords);
     }
 
-    return PLACES;
+    return Promise.resolve(PLACES);
 };
 
 // getting places from REST APIs
@@ -67,11 +67,11 @@ window.onload = () => {
 
                     // add place name
                     const text = document.createElement('a-link');
-                    text.setAttribute('gps-entity-place', `latitude: ${latitude}; longitude: ${longitude};`);
+                    text.setAttribute('data-gps_entity_place', `latitude: ${latitude}; longitude: ${longitude};`);
                     text.setAttribute('title', place.name);
                     text.setAttribute('href', 'http://www.example.com/');
                     text.setAttribute('scale', '20 20 20');
-                    
+
                     text.addEventListener('loaded', () => {
                         window.dispatchEvent(new CustomEvent('gps-entity-place-loaded'))
                     });

--- a/examples/places-name/places.js
+++ b/examples/places-name/places.js
@@ -67,7 +67,7 @@ window.onload = () => {
 
                     // add place name
                     const text = document.createElement('a-link');
-                    text.setAttribute('data-gps_entity_place', `latitude: ${latitude}; longitude: ${longitude};`);
+                    text.setAttribute('data-gps-entity-place', `latitude: ${latitude}; longitude: ${longitude};`);
                     text.setAttribute('title', place.name);
                     text.setAttribute('href', 'http://www.example.com/');
                     text.setAttribute('scale', '20 20 20');

--- a/examples/places-name/places.js
+++ b/examples/places-name/places.js
@@ -67,7 +67,7 @@ window.onload = () => {
 
                     // add place name
                     const text = document.createElement('a-link');
-                    text.setAttribute('data-gps-entity-place', `latitude: ${latitude}; longitude: ${longitude};`);
+                    text.setAttribute('gps-entity-place', `latitude: ${latitude}; longitude: ${longitude};`);
                     text.setAttribute('title', place.name);
                     text.setAttribute('href', 'http://www.example.com/');
                     text.setAttribute('scale', '20 20 20');

--- a/src/gps-camera-debug.js
+++ b/src/gps-camera-debug.js
@@ -21,7 +21,7 @@ AFRAME.registerComponent('gps-camera-debug', {
 
         this.placesLoadedEventHandler = function() {
             this.entities++;
-            const entities = document.querySelectorAll('[gps-entity-place]') && document.querySelectorAll('[gps-entity-place]').length || 0;
+            const entities = document.querySelectorAll('[data-gps_entity_place]') && document.querySelectorAll('[data-gps_entity_place]').length || 0;
 
             if (entities === this.entities) {
                 // all entities added, we can build debug UI
@@ -103,7 +103,7 @@ AFRAME.registerComponent('gps-camera-debug', {
      */
     _buildDistancesDebugUI: function() {
         const div = document.querySelector('.debug');
-        document.querySelectorAll('[gps-entity-place]').forEach((element) => {
+        document.querySelectorAll('[data-gps_entity_place]').forEach((element) => {
             const debugDiv = document.createElement('div');
             debugDiv.classList.add('debug-distance');
             debugDiv.innerHTML = element.getAttribute('value');

--- a/src/gps-camera-debug.js
+++ b/src/gps-camera-debug.js
@@ -21,7 +21,7 @@ AFRAME.registerComponent('gps-camera-debug', {
 
         this.placesLoadedEventHandler = function() {
             this.entities++;
-            const entities = document.querySelectorAll('[data-gps_entity_place]') && document.querySelectorAll('[data-gps_entity_place]').length || 0;
+            const entities = document.querySelectorAll('[data-gps-entity-place]') && document.querySelectorAll('[data-gps-entity-place]').length || 0;
 
             if (entities === this.entities) {
                 // all entities added, we can build debug UI
@@ -103,7 +103,7 @@ AFRAME.registerComponent('gps-camera-debug', {
      */
     _buildDistancesDebugUI: function() {
         const div = document.querySelector('.debug');
-        document.querySelectorAll('[data-gps_entity_place]').forEach((element) => {
+        document.querySelectorAll('[data-gps-entity-place]').forEach((element) => {
             const debugDiv = document.createElement('div');
             debugDiv.classList.add('debug-distance');
             debugDiv.innerHTML = element.getAttribute('value');

--- a/src/gps-camera-debug.js
+++ b/src/gps-camera-debug.js
@@ -21,7 +21,7 @@ AFRAME.registerComponent('gps-camera-debug', {
 
         this.placesLoadedEventHandler = function() {
             this.entities++;
-            const entities = document.querySelectorAll('[data-gps-entity-place]') && document.querySelectorAll('[data-gps-entity-place]').length || 0;
+            const entities = document.querySelectorAll('[gps-entity-place]') && document.querySelectorAll('[gps-entity-place]').length || 0;
 
             if (entities === this.entities) {
                 // all entities added, we can build debug UI
@@ -103,7 +103,7 @@ AFRAME.registerComponent('gps-camera-debug', {
      */
     _buildDistancesDebugUI: function() {
         const div = document.querySelector('.debug');
-        document.querySelectorAll('[data-gps-entity-place]').forEach((element) => {
+        document.querySelectorAll('[gps-entity-place]').forEach((element) => {
             const debugDiv = document.createElement('div');
             debugDiv.classList.add('debug-distance');
             debugDiv.innerHTML = element.getAttribute('value');


### PR DESCRIPTION
The `gps-entity-place` attribute wasn't being read on at least FF Android build 66.1.1 without prefixing it with `data-`. Changed  `gps-entity-place` to `data-gps_entity_place` in both places-name and click-places examples.
Returned a Promise instead of an object in loadPlaces function in the places-name example.